### PR TITLE
Add simple build test with github actions

### DIFF
--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -1,0 +1,33 @@
+name: Build Tests
+
+on:
+  push:
+    branches:
+    - 'master'
+  pull_request:
+    branches:
+    - '*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ubuntu_release: [
+          bionic
+          ]
+    container: px4io/px4-dev-simulation-${{ matrix.ubuntu_release }}:2020-04-01
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        token: ${{ secrets.ACCESS_TOKEN }}
+    - name: build
+      run:
+        apt update && apt install -y software-properties-common;
+        add-apt-repository ppa:saiarcot895/flightgear;
+        apt update;
+        apt install -y flightgear;
+        mkdir build;
+        cd build;
+        cmake ..;
+        make

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # FlightGear Bridge
 
+![Build Tests](https://github.com/PX4/PX4-FlightGear-Bridge/workflows/Build%20Tests/badge.svg)
+
 The FlightGear alternative to the current PX4's mainstream simulator Gazebo.
 
 ![FlightGear SITL connected with PX4 and QGroundControl](art/screenshot.png)


### PR DESCRIPTION
This Adds a simple build test for github actions.  Build is limited to bionic, since the PPA for flightgear seems to be missing on focal.

Needs fixing: Currently it is not ideal that everytime it runs flightgear is being reinstalled.