### PR TITLE
Remove flightgear installation from actions

### DIFF
--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -23,10 +23,6 @@ jobs:
         token: ${{ secrets.ACCESS_TOKEN }}
     - name: build
       run:
-        apt update && apt install -y software-properties-common;
-        add-apt-repository ppa:saiarcot895/flightgear;
-        apt update;
-        apt install -y flightgear;
         mkdir build;
         cd build;
         cmake ..;


### PR DESCRIPTION
Flightgear installation isn't necessary to build the code in this repo. Removing for now. 